### PR TITLE
BUGFIX: Prevent error from FUNDING parser

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,2 +1,2 @@
 patreon: shelzle
-github: sebobo
+#github: sebobo


### PR DESCRIPTION
When you use github funding and has not been accepted you get
a parsing error in the funding.yml. Github could be used when the
permission has been granted.