### PR TITLE
Amp analytics

### DIFF
--- a/Configuration/Settings.Blog.yaml
+++ b/Configuration/Settings.Blog.yaml
@@ -10,4 +10,4 @@ Shel:
       facebookId: ''
    analytics:
       tagManager:
-        id: ~   
+        ampContainerId: ~

--- a/Configuration/Settings.Blog.yaml
+++ b/Configuration/Settings.Blog.yaml
@@ -8,3 +8,6 @@ Shel:
       enabled: false
       twitterId: ''
       facebookId: ''
+   analytics:
+      tagManager:
+        id: ~   

--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ Shel:
   Blog:
     analytics:
       tagManager:
-        id: <gtm tag manager id>
+        ampContainerId: <gtm tag manager id>
 ```
+Please refer to [this page](https://support.google.com/tagmanager/answer/9205783?hl=en) for a detailed instruction how to set up a tagmanager container for amp
 
 Please test the AMP version every time you add new features to your blog pages!
 Also be sure to check Google Search Console on your live site as it will inform you of errors.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ If you have additional custom content elements in a blog article like videos and
 you might need to provide processors to make them compatible with AMP. 
 See the `replaceImgTags` image processor as example.
 
+If you have installed the neos/googleanalytics package aside with shel/blog all analytics tags will be diabled to be AMP confirmative.  
+You could add a tag manager with
+
+```yaml
+Shel:
+  Blog:
+    analytics:
+      tagManager:
+        id: <gtm tag manager id>
+```
+
 Please test the AMP version every time you add new features to your blog pages!
 Also be sure to check Google Search Console on your live site as it will inform you of errors.
 

--- a/Resources/Private/Fusion/Layouts/AmpPage.fusion
+++ b/Resources/Private/Fusion/Layouts/AmpPage.fusion
@@ -7,7 +7,7 @@ prototype(Shel.Blog:Layout.AmpPage) < prototype(Neos.Neos:Page) {
             <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
             <amp-analytics config={'https://www.googletagmanager.com/amp.json?id=' + Configuration.setting('Shel.Blog.analytics.tagManager.id') + '&gtm.url=SOURCE_URL'} data-credentials="include"></amp-analytics>
         `
-        @if.isset = ${Configuration.setting('Shel.Blog.amp.analytics.tagManager.id')}
+        @if.isset = ${Configuration.setting('Shel.Blog.amp.analytics.tagManager.ampContainerId')}
         @position = 'after headTag 100'
     }
 

--- a/Resources/Private/Fusion/Layouts/AmpPage.fusion
+++ b/Resources/Private/Fusion/Layouts/AmpPage.fusion
@@ -1,4 +1,16 @@
 prototype(Shel.Blog:Layout.AmpPage) < prototype(Neos.Neos:Page) {
+    # Disable Neos.GoogleAnalytics and include amp tag manager -> https://support.google.com/tagmanager/answer/9205783?hl=en
+    googleTagManagerNoScript >
+    googleTracking >
+    googleTracking = Neos.Fusion:Join {
+        main = afx`
+            <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+            <amp-analytics config={'https://www.googletagmanager.com/amp.json?id=' + Configuration.setting('Shel.Blog.analytics.tagManager.id') + '&gtm.url=SOURCE_URL'} data-credentials="include"></amp-analytics>
+        `
+        @if.isset = ${Configuration.setting('Shel.Blog.amp.analytics.tagManager.id')}
+        @position = 'after headTag 100'
+    }
+
     # Additional scripts are not allowed with amp
     lastVisitedNodeScript >
 

--- a/Resources/Private/Fusion/Layouts/AmpPage.fusion
+++ b/Resources/Private/Fusion/Layouts/AmpPage.fusion
@@ -2,14 +2,21 @@ prototype(Shel.Blog:Layout.AmpPage) < prototype(Neos.Neos:Page) {
     # Disable Neos.GoogleAnalytics and include amp tag manager -> https://support.google.com/tagmanager/answer/9205783?hl=en
     googleTagManagerNoScript >
     googleTracking >
-    googleTracking = Neos.Fusion:Join {
+    googleTrackingScript = Neos.Fusion:Join {
         main = afx`
             <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+        `
+        @if.isset = ${Configuration.setting('Shel.Blog.analytics.tagManager.id')}
+        @position = 'before closingHeadTag'
+    }
+    googleTrackingCustomElement = Neos.Fusion:Join {
+        main = afx`
             <amp-analytics config={'https://www.googletagmanager.com/amp.json?id=' + Configuration.setting('Shel.Blog.analytics.tagManager.id') + '&gtm.url=SOURCE_URL'} data-credentials="include"></amp-analytics>
         `
-        @if.isset = ${Configuration.setting('Shel.Blog.amp.analytics.tagManager.ampContainerId')}
-        @position = 'after headTag 100'
+        @if.isset = ${Configuration.setting('Shel.Blog.analytics.tagManager.id')}
+        @position = 'before closingBodyTag'
     }
+
 
     # Additional scripts are not allowed with amp
     lastVisitedNodeScript >


### PR DESCRIPTION
In the AMP specifications it is not allowed to add custom Javascript.
If you have installed the neos/googleanalytics package aside with shel/blog, the analytics package injects a tag with js after the head tag.  
This pull request remove this tag and adds the possibility to add an AMP confirmative version of a google tag manager according to this [answer](https://support.google.com/tagmanager/answer/9205783?hl=en)